### PR TITLE
feat: implement comment pagination system with metadata

### DIFF
--- a/controllers/interaction.controller.js
+++ b/controllers/interaction.controller.js
@@ -3,12 +3,14 @@ import {
 	toggleLike,
 	addComment,
 	getComments,
+	getCommentsPaginated,
 	deleteComment,
 	updateComment,
 } from "../services/interaction.service.js";
+import { validatePaginationParams } from "../utils/pagination-validation.js";
 
 const validatePostId = (postId) => {
-	const parsedId = parseInt(postId);
+	const parsedId = Number.parseInt(postId);
 	if (isNaN(parsedId) || parsedId <= 0) {
 		return null;
 	}
@@ -16,7 +18,7 @@ const validatePostId = (postId) => {
 };
 
 const validateCommentId = (commentId) => {
-	const parsedId = parseInt(commentId);
+	const parsedId = Number.parseInt(commentId);
 	if (isNaN(parsedId) || parsedId <= 0) {
 		return null;
 	}
@@ -126,6 +128,51 @@ export const getCommentsController = async (req, res) => {
 		});
 	} catch (err) {
 		console.error("Get Comments Controller Error:", err);
+
+		if (err.message === "Post not found") {
+			return res.status(404).json({
+				status: "error",
+				message: "Post not found",
+			});
+		}
+
+		return res.status(500).json({
+			status: "error",
+			message: "Failed to fetch comments",
+		});
+	}
+};
+
+export const getCommentsPaginatedController = async (req, res) => {
+	try {
+		const postId = validatePostId(req.params.postId);
+		const limit = req.query.limit || 5;
+		const offset = req.query.offset || 0;
+
+		if (!postId) {
+			return res.status(400).json({
+				status: "error",
+				message: "Invalid post ID",
+			});
+		}
+
+		const validation = validatePaginationParams(limit, offset);
+		if (!validation.isValid) {
+			return res.status(400).json({
+				status: "error",
+				message: validation.error,
+			});
+		}
+
+		const result = await getCommentsPaginated(postId, validation.limit, validation.offset);
+
+		return res.status(200).json({
+			status: "success",
+			message: "Comments fetched successfully",
+			data: result,
+		});
+	} catch (err) {
+		console.error("Get Comments Paginated Controller Error:", err);
 
 		if (err.message === "Post not found") {
 			return res.status(404).json({

--- a/routes/interaction.routes.js
+++ b/routes/interaction.routes.js
@@ -1,9 +1,9 @@
-// routes/interaction.routes.js
 import express from "express";
 import {
 	toggleLikeController,
 	addCommentController,
 	getCommentsController,
+	getCommentsPaginatedController,
 	deleteCommentController,
 	updateCommentController,
 } from "../controllers/interaction.controller.js";
@@ -17,22 +17,8 @@ interactionRoute.post("/posts/:postId/like", requireAuth, toggleLikeController);
 
 // Comment routes
 interactionRoute.get("/posts/:postId/comments", getCommentsController); // Public - anyone can view comments
-interactionRoute.post(
-	"/posts/:postId/comments",
-	requireAuth,
-	validateCommentData,
-	addCommentController,
-);
-interactionRoute.put(
-	"/comments/:commentId",
-	requireAuth,
-	validateCommentData,
-	updateCommentController,
-);
-interactionRoute.patch(
-	"/comments/:commentId",
-	requireAuth,
-	validateCommentData,
-	updateCommentController,
-);
+interactionRoute.get("/posts/:postId/comments/paginated", getCommentsPaginatedController); // Public - paginated comments
+interactionRoute.post("/posts/:postId/comments", requireAuth, validateCommentData, addCommentController);
+interactionRoute.put("/comments/:commentId", requireAuth, validateCommentData, updateCommentController);
+interactionRoute.patch("/comments/:commentId", requireAuth, validateCommentData, updateCommentController);
 interactionRoute.delete("/comments/:commentId", requireAuth, deleteCommentController);

--- a/services/interaction.service.js
+++ b/services/interaction.service.js
@@ -201,6 +201,58 @@ export const getComments = async (postId) => {
 	}
 };
 
+export const getCommentsPaginated = async (postId, limit = 5, offset = 0) => {
+	try {
+		// Check if post exists
+		const post = await prisma.post.findUnique({
+			where: { id: postId },
+		});
+
+		if (!post) {
+			throw new Error("Post not found");
+		}
+
+		// Get total count of comments for this post
+		const total = await prisma.comment.count({
+			where: { postId },
+		});
+
+		// Get paginated comments
+		const comments = await prisma.comment.findMany({
+			where: { postId },
+			orderBy: { createdAt: "desc" },
+			include: {
+				author: {
+					select: {
+						id: true,
+						name: true,
+					},
+				},
+			},
+			take: limit,
+			skip: offset,
+		});
+
+		// Calculate pagination metadata
+		const hasMore = offset + limit < total;
+		const nextOffset = offset + limit;
+
+		return {
+			comments,
+			pagination: {
+				total,
+				limit,
+				offset,
+				hasMore,
+				nextOffset,
+			},
+		};
+	} catch (error) {
+		console.error("Get comments paginated error:", error);
+		throw error;
+	}
+};
+
 export const deleteComment = async (userId, commentId) => {
 	try {
 		// Check if comment exists and user owns it

--- a/utils/pagination-validation.js
+++ b/utils/pagination-validation.js
@@ -1,0 +1,36 @@
+// Utility functions for pagination validation and handling
+
+export const validatePaginationParams = (limit, offset) => {
+	const parsedLimit = Number.parseInt(limit);
+	const parsedOffset = Number.parseInt(offset);
+
+	// Validate limit (1-50, default 5)
+	if (isNaN(parsedLimit) || parsedLimit < 1 || parsedLimit > 50) {
+		return {
+			isValid: false,
+			error: "Limit must be between 1 and 50",
+		};
+	}
+
+	// Validate offset (non-negative, default 0)
+	if (isNaN(parsedOffset) || parsedOffset < 0) {
+		return {
+			isValid: false,
+			error: "Offset must be a non-negative number",
+		};
+	}
+
+	return {
+		isValid: true,
+		limit: parsedLimit,
+		offset: parsedOffset,
+	};
+};
+
+export const calculateHasMore = (total, limit, offset) => {
+	return offset + limit < total;
+};
+
+export const calculateNextOffset = (limit, offset) => {
+	return offset + limit;
+};


### PR DESCRIPTION
Add paginated comment loading to prevent database overload and improve performance. Implement limit/offset pagination with configurable page size (default 5 comments).

Changes:
- Add pagination-validation.js utility for query parameter validation (limit: 1-50, offset: ≥0)
- Add getCommentsPaginated() service function with total count and hasMore metadata
- Add getCommentsPaginatedController() to handle paginated comment requests
- Add new route: GET /posts/:postId/comments/paginated?limit=5&offset=0
- Keep existing GET /posts/:postId/comments endpoint for backward compatibility
- Return pagination metadata: total, limit, offset, hasMore, nextOffset

Response includes:
- comments array with full comment objects
- pagination object with total count and hasMore flag for 'View More' functionality
- nextOffset for convenient pagination navigation

Resolves: Issue 3 - Comment System Enhancements